### PR TITLE
Moved Floating Windows to GameplayScreen

### DIFF
--- a/src/Components/AllTheFloatingWindows/AllTheFloatingWindows.js
+++ b/src/Components/AllTheFloatingWindows/AllTheFloatingWindows.js
@@ -1,0 +1,24 @@
+import React, { useContext } from 'react';
+import { MountedComponentsContext } from 'Contexts/MountedComponentsContext';
+import CoinsPurchaseWindow from 'Components/Coins/CoinsPurchaseWindow';
+import EnergyPurchaseWindow from 'Components/Energy/EnergyPurchaseWindow';
+
+export default function AllTheFloatingWindows() {
+  const { mountedComponentsDict, unmountComponents } = useContext(MountedComponentsContext);
+
+  const isCoinsPurchaseWindowMounted = mountedComponentsDict.CoinsPurchaseWindow;
+  const isEnergyPurchaseWindowMounted = mountedComponentsDict.EnergyPurchaseWindow;
+
+  const CoinsPurchaseWindowAsVar = (
+    <CoinsPurchaseWindow unmountCoinsPurchaseWindow={() => unmountComponents(['CoinsPurchaseWindow'])} />
+  );
+  const EnergyPurchaseWindowAsVar = (
+    <EnergyPurchaseWindow unmountEnergyPurchaseWindow={() => unmountComponents(['EnergyPurchaseWindow'])} />
+  );
+  return (
+    <div>
+      {isCoinsPurchaseWindowMounted && CoinsPurchaseWindowAsVar}
+      {isEnergyPurchaseWindowMounted && EnergyPurchaseWindowAsVar}
+    </div>
+  );
+}

--- a/src/Components/Coins/CoinsButton.js
+++ b/src/Components/Coins/CoinsButton.js
@@ -12,9 +12,9 @@ export default function CoinsButton() {
 
   const onCoinsButtonClick = () => {
     if (isCoinsTabOpen) {
-      unmountComponents(['CoinsTab', 'CoinsPurchaseWindow']);
+      unmountComponents('CoinsTab');
     } else {
-      mountComponents(['CoinsTab']);
+      mountComponents('CoinsTab');
     }
   };
 
@@ -23,7 +23,7 @@ export default function CoinsButton() {
       <GeneralButton id="coinsButton" uppercased outlined onButtonClick={() => onCoinsButtonClick(isCoinsTabOpen)}>
         {coinsButtonTexts.title}
       </GeneralButton>
-      {isCoinsTabOpen && <CoinsTab unmountCoinsTab={() => unmountComponents(['CoinsTab', 'CoinsPurchaseWindow'])} />}
+      {isCoinsTabOpen && <CoinsTab />}
     </div>
   );
 }

--- a/src/Components/Coins/CoinsTab.js
+++ b/src/Components/Coins/CoinsTab.js
@@ -1,27 +1,26 @@
 import React, { useContext } from 'react';
 import './CoinsTab.css';
 import GeneralButton from 'Components/GeneralComponents/GeneralButton';
-import CoinsPurchaseWindow from './CoinsPurchaseWindow';
 import { MountedComponentsContext } from 'Contexts/MountedComponentsContext';
 import GeneralTab from 'Components/GeneralComponents/GeneralTab';
 import { coinsTabTexts } from 'Texts/gameplayTexts';
 
 export default function CoinsTab() {
-  const { mountedComponentsDict, mountComponents, unmountComponents } = useContext(MountedComponentsContext);
+  const { mountComponents, unmountComponents } = useContext(MountedComponentsContext);
 
-  const isCoinsPurchaseWindowOpen = mountedComponentsDict.CoinsPurchaseWindow;
+  const getMoreButtonClickHandler = () => {
+    mountComponents('CoinsPurchaseWindow');
+    unmountComponents('CoinsTab');
+  };
 
   return (
     <GeneralTab id="coinsTab">
       {coinsTabTexts.coinsAmountPt1}
       XX
       {coinsTabTexts.coinsAmountPt2}
-      <GeneralButton id="getMoreCoinsButton" onButtonClick={() => mountComponents(['CoinsPurchaseWindow'])}>
+      <GeneralButton id="getMoreCoinsButton" onButtonClick={() => getMoreButtonClickHandler()}>
         {coinsTabTexts.getMore}
       </GeneralButton>
-      {isCoinsPurchaseWindowOpen && (
-        <CoinsPurchaseWindow unmountCoinsPurchaseWindow={() => unmountComponents(['CoinsPurchaseWindow'])} />
-      )}
     </GeneralTab>
   );
 }

--- a/src/Components/Energy/EnergyButton.js
+++ b/src/Components/Energy/EnergyButton.js
@@ -11,9 +11,9 @@ export default function EnergyButton() {
 
   const onEnergyButtonClick = () => {
     if (isEnergyTabOpen) {
-      unmountComponents(['EnergyTab', 'EnergyPurchaseWindow']);
+      unmountComponents('EnergyTab');
     } else {
-      mountComponents(['EnergyTab']);
+      mountComponents('EnergyTab');
     }
   };
 
@@ -22,7 +22,7 @@ export default function EnergyButton() {
       <GeneralButton uppercased outlined onButtonClick={onEnergyButtonClick} id="energyButton">
         {energyButtonTexts.title}
       </GeneralButton>
-      {isEnergyTabOpen && <EnergyTab unmountEnergyTab={() => unmountComponents(['EnergyTab', 'EnergyPurchaseWindow'])} />}
+      {isEnergyTabOpen && <EnergyTab />}
     </div>
   );
 }

--- a/src/Components/Energy/EnergyTab.js
+++ b/src/Components/Energy/EnergyTab.js
@@ -1,15 +1,18 @@
 import React, { useContext } from 'react';
 import './EnergyTab.css';
 import GeneralButton from 'Components/GeneralComponents/GeneralButton';
-import EnergyPurchaseWindow from './EnergyPurchaseWindow';
 import { MountedComponentsContext } from 'Contexts/MountedComponentsContext';
 import { energyTabTexts } from 'Texts/gameplayTexts';
 import EnergyIcon from 'Images/placeholderIcon.png';
 import GeneralTab from 'Components/GeneralComponents/GeneralTab';
 
 export default function EnergyTab() {
-  const { mountedComponentsDict, mountComponents, unmountComponents } = useContext(MountedComponentsContext);
-  const isEnergyPurchaseWindowOpen = mountedComponentsDict.EnergyPurchaseWindow;
+  const { mountComponents, unmountComponents } = useContext(MountedComponentsContext);
+
+  const getMoreButtonClickHandler = () => {
+    mountComponents('EnergyPurchaseWindow');
+    unmountComponents('EnergyTab');
+  };
 
   const energyIcon = <img src={EnergyIcon} alt="" className="tinyIcons" />;
 
@@ -33,13 +36,9 @@ export default function EnergyTab() {
         {energyTabTexts.perHour}
       </div>
 
-      <GeneralButton id="getMoreEnergyButton" onButtonClick={() => mountComponents(['EnergyPurchaseWindow'])}>
+      <GeneralButton id="getMoreEnergyButton" onButtonClick={() => getMoreButtonClickHandler()}>
         {energyTabTexts.getMore}
       </GeneralButton>
-
-      {isEnergyPurchaseWindowOpen && (
-        <EnergyPurchaseWindow unmountEnergyPurchaseWindow={() => unmountComponents(['EnergyPurchaseWindow'])} />
-      )}
     </GeneralTab>
   );
 }

--- a/src/Components/GeneralComponents/GeneralWindow.css
+++ b/src/Components/GeneralComponents/GeneralWindow.css
@@ -4,7 +4,6 @@
   background-color: #ddcc66;
   padding: 7px;
   border-radius: 5px;
-  z-index: 1;
 }
 
 .centered {

--- a/src/Screens/GameplayScreen/GameplayScreen.js
+++ b/src/Screens/GameplayScreen/GameplayScreen.js
@@ -11,6 +11,7 @@ import Map from 'Components/Map/Map';
 import DisastersIcon from 'Components/Disasters/DisastersIcon';
 import DisasterCounter from 'Components/Disasters/DisasterCounter';
 import MountedComponentsContextProvider from 'Contexts/MountedComponentsContext';
+import AllTheFloatingWindows from 'Components/AllTheFloatingWindows/AllTheFloatingWindows';
 
 export default function GameplayScreen() {
   return (
@@ -35,6 +36,7 @@ export default function GameplayScreen() {
           <CraftingButton />
         </div>
         <Map />
+        <AllTheFloatingWindows />
       </MountedComponentsContextProvider>
     </div>
   );


### PR DESCRIPTION
 - Created AllTheFloatingWindows Component.
 - rendered the above inside GameplayScreen.
 - removed The Purchase Windows rendering from coins's and energy's tabs.
 - changed the mounting and unmounting mechanic of coins's and energy's tabs and windows, now that the purchase windows can be rendered without the tabs.